### PR TITLE
quote master password in unlock

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -16,7 +16,7 @@ unlock_bw() {
   mpw=`rofi -dmenu -p 'Master Password' -password` || exit $?;
 
   if [ -z "$mpw" ]; then exit 1; fi
-  bw unlock $mpw | grep -e 'export.*=="' -o > $BW_HASH_FILE || exit $?;
+  bw unlock "$mpw" | grep -e 'export.*=="' -o > $BW_HASH_FILE || exit $?;
 
   source $BW_HASH_FILE
 }


### PR DESCRIPTION
given a master password with spaces, we need to quote the password string when passing to `bw unlock`.