### PR TITLE
Support xsel in addition to xclip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BitWarden Rofi Menu
 
-This is a work in progress to get the BitWarden cli functionality in an easy Rofi menu.  
+This is a work in progress to get the BitWarden cli functionality in an easy Rofi menu.
 On selecting an entry, the password is copied to your clipboard for 5 seconds. During those 5 seconds, a notification is shown indicating which password you are copying at that time.
 
 ![bitwarden-rofi](img/screenshot1.png)
@@ -24,4 +24,4 @@ You can either execute the script from a terminal or by binding it to a key comb
 
 - bitwarden-cli
 - jq
-- xclip
+- xclip or xsel

--- a/bwmenu
+++ b/bwmenu
@@ -149,7 +149,7 @@ clipboard-xclip-get() {
 }
 
 clipboard-xclip-clear() {
-    echo "" | xclip -selection clipboard -r
+    echo -n "" | xclip -selection clipboard -r
 }
 
 clipboard-xsel-set() {
@@ -173,7 +173,7 @@ show_password() {
   # send a notification for 5 seconds (-t 5000)
   # not sure if icon will be present everywhere, /usr/share/icons is default icon location
   notify-send "<b>$(echo "$1" | jq -r '.name')</b> copied" "${pass:0:4}****" -t 5000  -i /usr/share/icons/hicolor/64x64/apps/bitwarden.png
-  echo "$pass" | clipboard-set
+  echo -n "$pass" | clipboard-set
 
   sleep 5
   if [[ "$(clipboard-get)" == "$pass" ]]; then

--- a/bwmenu
+++ b/bwmenu
@@ -121,8 +121,10 @@ on_rofi_exit() {
 select_copy_command() {
   if hash xclip 2>/dev/null; then
     CLIPBOARD_MODE=xclip
+  elif hash xsel 2>/dev/null; then
+    CLIPBOARD_MODE=xsel
   else
-    exit_error 1 "No clipboard command found. Please install xclip."
+    exit_error 1 "No clipboard command found. Please install either xclip or xsel."
   fi
 }
 
@@ -148,6 +150,18 @@ clipboard-xclip-get() {
 
 clipboard-xclip-clear() {
     echo "" | xclip -selection clipboard -r
+}
+
+clipboard-xsel-set() {
+  xsel --clipboard --input
+}
+
+clipboard-xsel-get() {
+  xsel --clipboard
+}
+
+clipboard-xsel-clear() {
+  xsel --clipboard --delete
 }
 
 # Output the password

--- a/bwmenu
+++ b/bwmenu
@@ -7,6 +7,9 @@ BW_HASH_FILE=~/.bwhash
 # Holds the available items in memory
 ITEMS=
 
+# Stores which command will be used to deal with clipboards
+CLIPBOARD_MODE=
+
 # source the hash file to gain access to the BitWarden CLI
 # Pre fetch all the items
 load_items() {
@@ -114,6 +117,39 @@ on_rofi_exit() {
   esac
 }
 
+# Set $CLIPBOARD_MODE to a command that will put stdin into the clipboard.
+select_copy_command() {
+  if hash xclip 2>/dev/null; then
+    CLIPBOARD_MODE=xclip
+  else
+    exit_error 1 "No clipboard command found. Please install xclip."
+  fi
+}
+
+clipboard-set() {
+  clipboard-${CLIPBOARD_MODE}-set
+}
+
+clipboard-get() {
+  clipboard-${CLIPBOARD_MODE}-get
+}
+
+clipboard-clear() {
+  clipboard-${CLIPBOARD_MODE}-clear
+}
+
+clipboard-xclip-set() {
+    xclip -selection clipboard -r
+}
+
+clipboard-xclip-get() {
+    xclip -selection clipboard -o
+}
+
+clipboard-xclip-clear() {
+    echo "" | xclip -selection clipboard -r
+}
+
 # Output the password
 # copy to clipboard and give the user feedback that the password is copied
 # $1: json item
@@ -122,12 +158,12 @@ show_password() {
 
   # send a notification for 5 seconds (-t 5000)
   # not sure if icon will be present everywhere, /usr/share/icons is default icon location
-  notify-send "<b>`echo $1 | jq -r '.name'`</b> copied" "${pass:0:4}****" -t 5000  -i /usr/share/icons/hicolor/64x64/apps/bitwarden.png
-  echo $pass | xclip -selection clipboard -r
+  notify-send "<b>$(echo "$1" | jq -r '.name')</b> copied" "${pass:0:4}****" -t 5000  -i /usr/share/icons/hicolor/64x64/apps/bitwarden.png
+  echo "$pass" | clipboard-set
 
-  sleep 5;
-  if [ "`xclip -selection clipboard -o`" = "$pass" ]; then
-    echo '' | xclip -selection clipboard -r
+  sleep 5
+  if [[ "$(clipboard-get)" == "$pass" ]]; then
+    clipboard-clear
   fi
 }
 
@@ -136,5 +172,6 @@ if ! [ -f $BW_HASH_FILE ]; then
   chmod 600 $BW_HASH_FILE;
 fi
 
-load_items;
-show_items;
+select_copy_command
+load_items
+show_items

--- a/bwmenu
+++ b/bwmenu
@@ -15,13 +15,20 @@ load_items() {
 
   if [ $? -ne 0 ]; then
     mpw=`rofi -dmenu -p "Master Password" -password` || exit $?;
-    bw unlock "$mpw" | grep -e 'export.*=="' -o > $BW_HASH_FILE || { 
-      rofi -e "Failed to unlock BitWarden.
-Please try again."; 
-      exit 1; 
+    bw unlock "$mpw" | grep -e 'export.*=="' -o > $BW_HASH_FILE || {
+      exit_error 1 "Failed to unlock BitWarden.
+Please try again."
     }
     load_items;
   fi
+}
+
+exit_error() {
+  local code="$1"
+  local message="$2"
+
+  rofi -e "$message"
+  exit "$code"
 }
 
 # Show the Rofi menu with options
@@ -33,7 +40,7 @@ rofi_menu() {
     -kb-custom-1 alt+r \
     -kb-custom-2 alt+n \
     -kb-custom-3 alt+u \
-    -kb-custom-4 alt+c 
+    -kb-custom-4 alt+c
 
 }
 
@@ -90,10 +97,7 @@ show_folders() {
 
 # re-sync the BitWarden items with the server
 sync_bitwarden() {
-  bw sync &>/dev/null || {
-    rofi -e "Failed to sync bitwarden"
-    exit 1;
-  }
+  bw sync &>/dev/null || exit_error 1 "Failed to sync bitwarden"
 
   load_items
   show_items
@@ -101,7 +105,7 @@ sync_bitwarden() {
 
 # Evaluate the rofi exit codes
 on_rofi_exit() {
-  case "$1" in 
+  case "$1" in
     10) sync_bitwarden;;
     11) load_items; show_items;;
     12) show_urls;;
@@ -118,7 +122,7 @@ show_password() {
 
   # send a notification for 5 seconds (-t 5000)
   # not sure if icon will be present everywhere, /usr/share/icons is default icon location
-  notify-send "<b>`echo $1 | jq -r '.name'`</b> copied" "${pass:0:4}****" -t 5000  -i /usr/share/icons/hicolor/64x64/apps/bitwarden.png 
+  notify-send "<b>`echo $1 | jq -r '.name'`</b> copied" "${pass:0:4}****" -t 5000  -i /usr/share/icons/hicolor/64x64/apps/bitwarden.png
   echo $pass | xclip -selection clipboard -r
 
   sleep 5;


### PR DESCRIPTION
I didn't have xclip installed, and I'd rather this tool supported more adapters than me having to install another one. :stuck_out_tongue: 

I hope you find this acceptable. I tried to abstract it in a way that it would be easy to add support for more tools later if the need arises.

**Extra:**

- If you run `bwmenu` without either of these tools installed, you get an error immediately instead of being falsely led along and have the script fail at the last point.