### PR TITLE
don't use X tools when using Wayland or vice-versa

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,4 @@ Copyright © 2018-2019
   * Matthias De Bie
   * Remy Rojas
   * Baptiste Pierrat
+  * Nathan Wallace

--- a/bwmenu
+++ b/bwmenu
@@ -240,9 +240,9 @@ auto_type() {
 # Set $AUTOTYPE_MODE to a command that will emulate keyboard input
 select_autotype_command() {
   if [[ -z "$AUTOTYPE_MODE" ]]; then
-    if hash ydotool 2>/dev/null; then
+    if [ "$XDG_SESSION_TYPE" = "wayland" ] && hash ydotool 2>/dev/null; then
       AUTOTYPE_MODE=(sudo ydotool)
-    elif hash xdotool 2>/dev/null; then
+    elif [ "$XDG_SESSION_TYPE" != "wayland" ] && hash xdotool 2>/dev/null; then
       AUTOTYPE_MODE=xdotool
     fi
   fi
@@ -260,15 +260,14 @@ type_tab() {
 # Set $CLIPBOARD_MODE to a command that will put stdin into the clipboard.
 select_copy_command() {
   if [[ -z "$CLIPBOARD_MODE" ]]; then
-    if hash xclip 2>/dev/null; then
+    if [ "$XDG_SESSION_TYPE" = "wayland" ]; then
+      hash wl-copy 2>/dev/null && CLIPBOARD_MODE=wayland
+    elif hash xclip 2>/dev/null; then
       CLIPBOARD_MODE=xclip
     elif hash xsel 2>/dev/null; then
       CLIPBOARD_MODE=xsel
-    elif hash wl-copy 2>/dev/null; then
-      CLIPBOARD_MODE=wayland
-    else
-      exit_error 1 "No clipboard command found. Please install either xclip, xsel, or wl-clipboard."
     fi
+    [ -z "$CLIPBOARD_MODE" ] && exit_error 1 "No clipboard command found. Please install either xclip, xsel, or wl-clipboard."
   fi
 }
 


### PR DESCRIPTION
xclip and xsel won't work on Wayland sessions, and wl-clipboard won't
work on X11 sessions. Therefore, it's better to detect the session type
(via $XDG_SESSION_TYPE), then decide on what clipboard management to
use, rather than simply checking what's installed.

Additionally, if a user has both X and Wayland clipboard tools
installed, this will choose the right one based on their session.
Previously, it would always choose the X clipboard manager.