### PR TITLE
Replace tab with Tab for xdotool

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -253,7 +253,7 @@ type_word() {
 }
 
 type_tab() {
-  "${AUTOTYPE_MODE[@]}" key tab
+  "${AUTOTYPE_MODE[@]}" key Tab
 }
 
 


### PR DESCRIPTION
@touste Could you check this for me with ydotool? The lowercase tab did not work for xdotool and the ydotool documentation only states that in most cases just change 'x' with 'y' so I suppose this will work as well?