### PR TITLE
Handle quotes and backslashes in item names

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -175,13 +175,13 @@ show_folders() {
   folders=$(bw list folders --session "$BW_HASH")
   if folder=$(echo "$folders" | jq -r '.[] | .name' | rofi_menu); then
 
-    folder_id=$(echo "$folders" | jq -r ".[] | select(.name == \"$folder\").id")
+    folder_id=$(echo "$folders" | jq -r ".[] | select(.name == $(jq_escape "$folder")).id")
 
     ITEMS=$(bw list items --folderid "$folder_id" --session "$BW_HASH")
     show_items
   else
     rofi_exit_code="$?"
-    folder_id=$(echo "$folders" | jq -r ".[] | select(.name == \"$folder\").id")
+    folder_id=$(echo "$folders" | jq -r ".[] | select(.name == $(jq_escape "$folder")).id")
     item_array=$(bw list items --folderid "$folder_id" --session "$BW_HASH")
     on_rofi_exit "$rofi_exit_code" "$item_array"
   fi

--- a/lib-bwmenu
+++ b/lib-bwmenu
@@ -1,17 +1,23 @@
 #!/bin/bash
 # Helper functions
 
+# Escape the argument into a valid jq string literal (with quotes included)
+# $1: string to escape
+jq_escape() {
+	echo -n "$1" | jq -Rs
+}
+
 # Extract item or items matching .name, including deduplication
 # $1: item name, prepended or not with deduplication mark
 array_from_name() {
-  item_name="$(echo "$1" | sed "s/$DEDUP_MARK //")"
-  echo "$ITEMS" | jq -r ". | map(select((.name == \"$item_name\") and (.type == $TYPE_LOGIN)))"
+  item_name=$(jq_escape "${1#$DEDUP_MARK }")
+  echo "$ITEMS" | jq -r "map(select((.name == $item_name) and (.type == $TYPE_LOGIN)))"
 }
 
 # Extract item matching .id
 # $1: string starting with ".id:"
 array_from_id() {
-  echo "$ITEMS" | jq -r ". | map(select(.id == \"$1\"))"
+  echo "$ITEMS" | jq -r ". | map(select(.id == $(jq_escape $1)))"
 }
 
 # Count the number of items in an array. Return true if more than 1 or none


### PR DESCRIPTION
Fixes #35

My vault has an item that has quotes in the name, and it derails `bwmenu` in a way that forces me to `pkill bwmenu`

I found that the problem is that the item and folder names are being directly used in some jq filters, artificially wrapped in quotes, like this:
```jq
select(.name == \"$item_name\")
```
If `$item_name` has quotes or backslashes, its expansion will create a jq syntax error.

I found [this solution on StackOverflow](https://stackoverflow.com/questions/10053678/escaping-characters-in-bash-for-json/50380697#50380697) that makes jq slurp a string like `$item_name` from stdin and output the correctly JSON-encoded version of it, and decided to incorporate it in the script.
```jq
select(.name == $(echo -n "$item_name" | jq -Rs))
```
I am confident that bitwarden-rofi will now be capable of handling the weirdest item names and folder names we can put in our vaults!

---

PS: I made an alternative [branch](https://github.com/diogotito/bitwarden-rofi/tree/jq-escape-stdin) where my `jq_escape` function gets the input string from stdin, but I'm afraid it makes the code that uses it a little harder to understand. It also shows that `jq_escape` is a bit useless by itself, but I believe it make it more obvious what's happening to the names. 