### PR TITLE
pass ROFI_OPTIONS in ask_password

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -49,7 +49,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 source "$DIR/lib-bwmenu"
 
 ask_password() {
-  mpw=$(printf '' | rofi -dmenu -p "Master Password" -password -lines 0) || exit $?
+  mpw=$(printf '' | rofi -dmenu -p "Master Password" -password -lines 0 ${ROFI_OPTIONS[@]}) || exit $?
   echo "$mpw" | bw unlock 2>/dev/null | grep 'export' | sed -E 's/.*export BW_SESSION="(.*==)"$/\1/' || exit_error $? "Could not unlock vault"
 }
 


### PR DESCRIPTION
I was playing around with several rofi theming options and noticed that my options were not applied when `bwmenu` was asking for the master passwort. With my patch the options will be passed to rofi when asking for the passwort.