### PR TITLE
Copy TOTP code to clipboard when using auto_type all

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -351,7 +351,7 @@ copy_totp() {
   else
     id=$(echo "$1" | jq -r ".[0].id")
 
-    if ! totp=$(bw --session "$BW_HASH" get totp "$id"); then
+    if ! totp=$(bw --session "$BW_HASH" get totp "$id" 2>/dev/null); then
       exit_error 1 "$totp"
     fi
 

--- a/bwmenu
+++ b/bwmenu
@@ -225,6 +225,7 @@ auto_type() {
         type_word "$(echo "$2" | jq -r '.[0].login.username')"
         type_tab
         type_word "$(echo "$2" | jq -r '.[0].login.password')"
+        copy_totp "$2"
         ;;
       username)
         type_word "$(echo "$2" | jq -r '.[0].login.username')"


### PR DESCRIPTION
I found it a little annoying that I had to use `bwmenu` twice to use autotype and then copy the TOTP code. The Bitwarden browser plugin automatically copies the code into the clipboard after autotyping. I think this is quite useful, so here's another pull request that does that.

I had to add STDERR redirection to /dev/null because bw was returning an error message when no TOTP code exists, and this error message made a small rofi window appear after autotyping w/o TOTP. The redirection makes the stray window disappear.

Btw., this small modification really made me appreciate how well you implemented the features, it's all very modular and easy to understand :+1: Going into the code I did not expect this to be a one line change. 