### PR TITLE
copy TOTP when using auto_type all

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -82,8 +82,9 @@ load_items() {
 exit_error() {
   local code="$1"
   local message="$2"
-
-  rofi -e "$message"
+  if [ $message ]; then
+    rofi -e "$message"
+  fi
   exit "$code"
 }
 
@@ -225,6 +226,7 @@ auto_type() {
         type_word "$(echo "$2" | jq -r '.[0].login.username')"
         type_tab
         type_word "$(echo "$2" | jq -r '.[0].login.password')"
+        copy_totp "$2"
         ;;
       username)
         type_word "$(echo "$2" | jq -r '.[0].login.username')"


### PR DESCRIPTION
This PR will copy the TOTP token into the clipboard when using `auto_type all`, this is way more convenient because you don't have to run `bwmenu` twice.

The modification in `exit_error` was necessary because the `copy_totp` function will call `exit_error` with an effectively empty error message and that would result in a rofi popup every time autotype was used and the item did not contain a TOTP token. Only showing rofi when the message is not empty did not break any other behavior during my tests.