### PR TITLE
Add caching of items to reduce loading time

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -12,7 +12,7 @@ AUTO_LOCK=900 # 15 minutes, default for bitwarden apps
 
 # Holds the available items in memory
 ITEMS=
-CACHE_FILE=$HOME/.cache/bwmenu/logins.gpg
+CACHE_FILE=/tmp/bwmenu/logins.gpg
 
 # Stores which command will be used to emulate keyboard type
 AUTOTYPE_MODE=
@@ -76,7 +76,7 @@ get_session_key() {
 # Load encrypted passwords from cache if exists
 load_cache() {
   if [ -f "$CACHE_FILE" ]; then
-    ITEMS=$(gpg --quiet -d --batch --passphrase $BW_HASH $CACHE_FILE)
+    ITEMS=$(gpg --quiet -d --batch --passphrase $BW_HASH --cipher-algo AES256 $CACHE_FILE)
   else
     load_items
   fi
@@ -91,7 +91,7 @@ load_items() {
 
   # create dir for cache and encrypt $ITEMS
   mkdir -p $(dirname $CACHE_FILE)
-  echo "$ITEMS" | gpg -c --batch --passphrase $BW_HASH -o $CACHE_FILE
+  echo "$ITEMS" | gpg -c --batch --passphrase $BW_HASH --cipher-algo AES256 -o $CACHE_FILE
 }
 
 exit_error() {
@@ -136,6 +136,7 @@ rofi_menu() {
 
 # Show items in a rofi menu by name of the item
 show_items() {
+	echo "$BW_HASH"
   if item=$(
     echo "$ITEMS" \
     | jq -r ".[] | select( has( \"login\" ) ) | \"\\(.name)\"" \

--- a/bwmenu
+++ b/bwmenu
@@ -12,6 +12,7 @@ AUTO_LOCK=900 # 15 minutes, default for bitwarden apps
 
 # Holds the available items in memory
 ITEMS=
+CACHE_FILE=$HOME/.cache/bwmenu/logins.gpg
 
 # Stores which command will be used to emulate keyboard type
 AUTOTYPE_MODE=
@@ -49,6 +50,7 @@ DIR="$(dirname "$(readlink -f "$0")")"
 source "$DIR/lib-bwmenu"
 
 ask_password() {
+  rm $CACHE_FILE
   mpw=$(printf '' | rofi -dmenu -p "Master Password" -password -lines 0) || exit $?
   echo "$mpw" | bw unlock 2>/dev/null | grep 'export' | sed -E 's/.*export BW_SESSION="(.*==)"$/\1/' || exit_error $? "Could not unlock vault"
 }
@@ -71,12 +73,25 @@ get_session_key() {
   fi
 }
 
+# Load encrypted passwords from cache if exists
+load_cache() {
+  if [ -f "$CACHE_FILE" ]; then
+    ITEMS=$(gpg --quiet -d --batch --passphrase $BW_HASH $CACHE_FILE)
+  else
+    load_items
+  fi
+}
+
 # source the hash file to gain access to the BitWarden CLI
 # Pre fetch all the items
 load_items() {
   if ! ITEMS=$(bw list items --session "$BW_HASH" 2>/dev/null); then
     exit_error $? "Could not load items"
   fi
+
+  # create dir for cache and encrypt $ITEMS
+  mkdir -p $(dirname $CACHE_FILE)
+  echo "$ITEMS" | gpg -c --batch --passphrase $BW_HASH -o $CACHE_FILE
 }
 
 exit_error() {
@@ -191,6 +206,7 @@ show_folders() {
 sync_bitwarden() {
   bw sync --session "$BW_HASH" &>/dev/null || exit_error 1 "Failed to sync bitwarden"
 
+  rm $CACHE_FILE
   load_items
   show_items
 }
@@ -496,5 +512,5 @@ parse_cli_arguments "$@"
 get_session_key
 select_autotype_command
 select_copy_command
-load_items
+load_cache
 show_items

--- a/bwmenu
+++ b/bwmenu
@@ -136,7 +136,6 @@ rofi_menu() {
 
 # Show items in a rofi menu by name of the item
 show_items() {
-	echo "$BW_HASH"
   if item=$(
     echo "$ITEMS" \
     | jq -r ".[] | select( has( \"login\" ) ) | \"\\(.name)\"" \


### PR DESCRIPTION
Adresses issue #51: went from `~1.09s `to `~0.31s` for me.

Some comments:
- write `ITEMS` to caching file (`/tmp/bwmenu/logins.gpg`)
- file is encrypted using `gpg` default algorithm (`AES256`, which is used by BW)
   - could change with `--cipher algo` (see available options with `gpg --version`
   - passphrase is the `BW_HASH`, since having the session key would also grant access to the vault of `bw` (?)