### PR TITLE
Use "/usr/bin/env bash" instead of "/bin/bash"

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Rofi extension for BitWarden-cli
 NAME="$(basename "$0")"
 VERSION="0.4"


### PR DESCRIPTION
On some systems `/bin/bash` doesn't exist. E.g. NixOS.
So this change will make `bitwarden-rofi` more compatible with other systems.