### PR TITLE
Fix xdotool typing issue 

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -249,7 +249,10 @@ select_autotype_command() {
 }
 
 type_word() {
+  DEFAULT_LAYOUT="$(setxkbamp -query | grep layout | awk '{print $2}')"
+  setxkbamp us
   "${AUTOTYPE_MODE[@]}" type "$1"
+  setxkbamp ${DEFAULT_LAYOUT}
 }
 
 type_tab() {


### PR DESCRIPTION
# Problem encountered
A user with multiple keyboard layouts may encounter an error when auto typing its password depending on the layouts.

On my machine, I have two layouts set at the same time, and I switch between them using the Caps lock key.
```bash
$ setxkbmap -query
rules:      evdev
model:      pc105
layout:     us,fr
options:    grp:caps_toggle
```

It seems like xdotool has an issue when picking its typing layout, it takes the last layout instead of the currently active one (problem with xdotool and Xorg as I read on other forums).

An easy way to fix it would be to reverse the layout order as follows : 
```bash
$ setxkbmap -query
rules:      evdev
model:      pc105
layout:     fr,us
options:    grp:caps_toggle
```

It would fix the problem for me but I guess it might not be the case for everyone.

# Solution
The fix I currently suggest is as follows : 
- saving the current layout configuration
- setting the keyboard layout to `us`
- executing `xdotool type`
- setting the keyboard layout back to its initial configuration

On the second step, the layout can be anything as long as it is a single layout. Xdotool 'misstypes' the string only when two conflicting layouts are set at the same time.