### PR TITLE
Add support for wtype instead of ydotool on Wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Quick Actions:
   Alt+c  Search through folders
 
   Alt+t  Copy the TOTP
-  Alt+1  Autotype the username and password [needs xdotool (Xorg) / ydotool (Wayland)]
-  Alt+2  Autotype the username [needs xdotool (Xorg) / ydotool (Wayland)]
-  Alt+3  Autotype the password [needs xdotool (Xorg) / ydotool (Wayland)]
+  Alt+1  Autotype the username and password [needs xdotool (Xorg) / wtype or ydotool (Wayland)]
+  Alt+2  Autotype the username [needs xdotool (Xorg) / wtype or ydotool (Wayland)]
+  Alt+3  Autotype the password [needs xdotool (Xorg) / wtype or ydotool (Wayland)]
   
   Alt+L  Lock your vault
 
@@ -88,7 +88,7 @@ You can use bitwarden-rofi to auto type your *username*, *password* or *both* by
   - <kbd>Alt</kbd>+<kbd>2</kbd>: Type only the username
   - <kbd>Alt</kbd>+<kbd>3</kbd>: Type only the password
  
-> __Wayland Users__: For autotyping to work in Wayland, you will need [`ydotool`](https://github.com/ReimuNotMoe/ydotool) working with root permissions (it needs access to /dev/uinput) without asking for password. For example, this can be achieved by adding this line in `visudo`:
+> __Wayland Users__: For autotyping to work in Wayland, you will need either [`wtype`](https://github.com/atx/wtype), or [`ydotool`](https://github.com/ReimuNotMoe/ydotool). If using `ydotool`, it needs to be working with root permissions to access `/dev/uinput` without asking for password. For example, this can be achieved by adding this line in `visudo`:
 
 `your_username ALL=(ALL) NOPASSWD: /usr/bin/ydotool`
 
@@ -105,7 +105,7 @@ You can use bitwarden-rofi to auto type your *username*, *password* or *both* by
 Install the `bitwarden-rofi` AUR package for the latest release or the `bitwarden-rofi-git` for the current master.  
 For copying or autotyping, install:
 - *xorg*: `xclip`,`xsel` and/or `xdotool` 
-- *wayland*: `wl-clipboard` and `ydotool`
+- *wayland*: `wl-clipboard` and either `wtype` or `ydotool`
 
 ### Via source
 
@@ -119,7 +119,7 @@ Install these **required** dependencies:
 
 **Optionally** install these requirements:
 - xclip, xsel, or wl-clipboard
-- xdotool or ydotool
+- xdotool, wtype, or ydotool
 
 Then download the script file and place it somewhere on your `$PATH` and grant it
 the `+x` permission.

--- a/bwmenu
+++ b/bwmenu
@@ -211,7 +211,7 @@ on_rofi_exit() {
   esac
 }
 
-# Auto type using xdotool/ydotool
+# Auto type using xdotool/ydotool/wtype
 # $1: what to type; all, username, password
 # $2: item array
 auto_type() {
@@ -240,20 +240,28 @@ auto_type() {
 # Set $AUTOTYPE_MODE to a command that will emulate keyboard input
 select_autotype_command() {
   if [[ -z "$AUTOTYPE_MODE" ]]; then
-    if [ "$XDG_SESSION_TYPE" = "wayland" ] && hash ydotool 2>/dev/null; then
+    if [ "$XDG_SESSION_TYPE" = "wayland" ] && hash wtype 2>/dev/null; then
+      AUTOTYPE_MODE=wtype
+      AUTOTYPE_TYPE_ARG=
+      AUTOTYPE_KEY_ARG="-P"
+    elif [ "$XDG_SESSION_TYPE" = "wayland" ] && hash ydotool 2>/dev/null; then
       AUTOTYPE_MODE=(sudo ydotool)
+      AUTOTYPE_TYPE_ARG="type"
+      AUTOTYPE_KEY_ARG="key"
     elif [ "$XDG_SESSION_TYPE" != "wayland" ] && hash xdotool 2>/dev/null; then
       AUTOTYPE_MODE=xdotool
+      AUTOTYPE_TYPE_ARG="type"
+      AUTOTYPE_KEY_ARG="key"
     fi
   fi
 }
 
 type_word() {
-  "${AUTOTYPE_MODE[@]}" type "$1"
+  "${AUTOTYPE_MODE[@]}" $AUTOTYPE_TYPE_ARG "$1"
 }
 
 type_tab() {
-  "${AUTOTYPE_MODE[@]}" key Tab
+  "${AUTOTYPE_MODE[@]}" $AUTOTYPE_KEY_ARG Tab
 }
 
 
@@ -437,9 +445,9 @@ Quick Actions:
   $KB_FOLDERSELECT  Search through folders
 
   $KB_TOTPCOPY  Copy the TOTP
-  $KB_TYPEALL  Autotype the username and password [needs xdotool or ydotool]
-  $KB_TYPEUSER  Autotype the username [needs xdotool or ydotool]
-  $KB_TYPEPASS  Autotype the password [needs xdotool or ydotool]
+  $KB_TYPEALL  Autotype the username and password [needs xdotool, wtype, or ydotool]
+  $KB_TYPEUSER  Autotype the username [needs xdotool, wtype, or ydotool]
+  $KB_TYPEPASS  Autotype the password [needs xdotool, wtype, or ydotool]
   
   $KB_LOCK  Lock your vault
 


### PR DESCRIPTION
For your consideration, I've added support to use [`wtype`](https://github.com/atx/wtype) for autotyping on Wayland in place of `ydotool` if it is available.

My preference for `wtype` is because it doesn't require root permissions to work, and also the `ydotool` author(s) have indicated they may no longer be supporting the project going forward.