### PR TITLE
fix type_tab function to type a tab char via key code

### DIFF
--- a/bwmenu
+++ b/bwmenu
@@ -286,7 +286,7 @@ type_word() {
 }
 
 type_tab() {
-  "${AUTOTYPE_MODE[@]}" key $CLEAR_MODIFIERS Tab
+  "${AUTOTYPE_MODE[@]}" key $CLEAR_MODIFIERS 15:1 15:0
 }
 
 


### PR DESCRIPTION
Fix the `type_tab` function by specifying `tab` via character code defined in `/usr/include/linux/input-event-codes.h` instead of an alias.